### PR TITLE
Add English language support

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/qr-finder.svg" />
+    <link rel="alternate icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
+    <!-- Primary Meta Tags -->
+    <title>QR Visualizer - Learn How QR Codes Work</title>
+    <meta name="title" content="QR Visualizer - Learn How QR Codes Work" />
+    <meta name="description" content="Visualize each step of QR code encoding and decoding. Explore the entire process interactively." />
+    <meta name="keywords" content="QR code, visualization, Reed-Solomon, error correction, ISO/IEC 18004, encoding, decoding" />
+    <meta name="author" content="yongsk0066" />
+    
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://yongsk0066.github.io/qr-visualizer/" />
+    <meta property="og:title" content="QR Visualizer - Learn How QR Codes Work" />
+    <meta property="og:description" content="Visualize each step of QR code encoding and decoding. Explore the entire process interactively." />
+    <meta property="og:image" content="https://yongsk0066.github.io/qr-visualizer/og-image.png" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="QR Visualizer" />
+    
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://yongsk0066.github.io/qr-visualizer/" />
+    <meta property="twitter:title" content="QR Visualizer - Learn How QR Codes Work" />
+    <meta property="twitter:description" content="Visualize each step of QR code encoding and decoding. Explore the entire process interactively." />
+    <meta property="twitter:image" content="https://yongsk0066.github.io/qr-visualizer/og-image.png" />
+    <meta property="twitter:creator" content="@yongsk0066" />
+    
+    <!-- Additional Meta Tags -->
+    <meta name="robots" content="index, follow" />
+    <meta name="language" content="English" />
+    <meta name="revisit-after" content="7 days" />
+    <link rel="canonical" href="https://yongsk0066.github.io/qr-visualizer/" />
+    
+    <!-- Theme Color -->
+    <meta name="theme-color" content="#1a1a1a" />
+    
+    <!-- Apple Touch Icon -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    
+    <script async src="/opencv.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QREncodingProcess } from './components/QREncodingProcess';
 import { QRDecodeProcess } from './components/QRDecodeProcess';
 import type { TriStateQR } from './qr-decode/types';
 import mascot from './assets/mascot.gif';
+import { t } from './lang';
 
 function App() {
   const [encodedQRMatrix, setEncodedQRMatrix] = useState<number[][] | null>(null);
@@ -13,15 +14,17 @@ function App() {
   return (
     <div className="app">
       <header className="mb-8 flex items-center gap-4">
-        <img 
-          src={mascot} 
-          alt="QR Visualizer 마스코트" 
+        <img
+          src={mascot}
+          alt={t('QR Visualizer 마스코트', 'QR Visualizer mascot')}
           className="w-16 h-16 object-contain"
-          title="안녕하세요! QR 코드를 함께 배워봐요 👋"
+          title={t('안녕하세요! QR 코드를 함께 배워봐요 👋', 'Hello! Let\'s learn QR codes together 👋')}
         />
         <div>
           <h1 className="text-3xl font-light tracking-wide mb-1">QR Visualizer</h1>
-          <p className="text-gray-600 text-sm">QR 코드 생성 과정 학습</p>
+          <p className="text-gray-600 text-sm">
+            {t('QR 코드 생성 과정 학습', 'Learn how QR codes are generated')}
+          </p>
         </div>
       </header>
 

--- a/src/components/decode/DataExtractionColumn.tsx
+++ b/src/components/decode/DataExtractionColumn.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { DataExtractionResult } from '../../qr-decode/decode/data-extraction/types';
+import { t } from '../../lang';
 
 interface DataExtractionColumnProps {
   dataExtractionResult: DataExtractionResult | null;
@@ -16,7 +17,7 @@ export function DataExtractionColumn({
   if (!dataExtractionResult || !correctedDataCodewords) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">6단계: 데이터 추출</h2>
+        <h2 className="font-medium mb-3">{t('6단계: 데이터 추출', 'Step 6: Data Extraction')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -73,7 +74,7 @@ export function DataExtractionColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">6단계: 데이터 추출</h2>
+      <h2 className="font-medium mb-3">{t('6단계: 데이터 추출', 'Step 6: Data Extraction')}</h2>
 
       <div className="space-y-4">
         <p className="text-sm text-gray-600">

--- a/src/components/decode/DataReadingColumn.tsx
+++ b/src/components/decode/DataReadingColumn.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import type { DataReadingResult } from '../../qr-decode/decode/data-reading/types';
+import { t } from '../../lang';
 import { copyHexArrayToClipboard, showCopyNotification } from '../../shared/utils';
 
 interface DataReadingColumnProps {
@@ -113,7 +114,7 @@ export function DataReadingColumn({
   if (!dataReadingResult || !unmaskedMatrix || !dataModules) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">4단계: 데이터 모듈 읽기</h2>
+        <h2 className="font-medium mb-3">{t('4단계: 데이터 모듈 읽기', 'Step 4: Data Reading')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -159,7 +160,7 @@ export function DataReadingColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">4단계: 데이터 모듈 읽기</h2>
+      <h2 className="font-medium mb-3">{t('4단계: 데이터 모듈 읽기', 'Step 4: Data Reading')}</h2>
       
       <div className="space-y-4">
         <p className="text-sm text-gray-600">

--- a/src/components/decode/ErrorCorrectionColumn.tsx
+++ b/src/components/decode/ErrorCorrectionColumn.tsx
@@ -1,4 +1,5 @@
 import type { ErrorCorrectionResult } from '../../qr-decode/decode/error-correction/types';
+import { t } from '../../lang';
 
 interface ErrorCorrectionColumnProps {
   errorCorrectionResult: ErrorCorrectionResult | null;
@@ -12,7 +13,7 @@ export function ErrorCorrectionColumn({
   if (!errorCorrectionResult || !codewords) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">5단계: 에러 정정</h2>
+        <h2 className="font-medium mb-3">{t('5단계: 에러 정정', 'Step 5: Error Correction')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -44,7 +45,7 @@ export function ErrorCorrectionColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">5단계: 에러 정정</h2>
+      <h2 className="font-medium mb-3">{t('5단계: 에러 정정', 'Step 5: Error Correction')}</h2>
 
       <div className="space-y-4">
         <p className="text-sm text-gray-600">

--- a/src/components/decode/FormatExtractionColumn.tsx
+++ b/src/components/decode/FormatExtractionColumn.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { FormatInfoResult } from '../../qr-decode/decode/format-extraction/types';
 import type { TriStateQR } from '../../qr-decode/types';
+import { t } from '../../lang';
 
 interface FormatExtractionColumnProps {
   formatInfo: FormatInfoResult | null;
@@ -92,7 +93,7 @@ export function FormatExtractionColumn({ formatInfo, triStateMatrix }: FormatExt
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">1단계: 포맷 정보 추출</h2>
+      <h2 className="font-medium mb-3">{t('1단계: 포맷 정보 추출', 'Step 1: Format Extraction')}</h2>
       
       <div className="space-y-4">
         <p className="text-sm text-gray-600">

--- a/src/components/decode/MaskRemovalColumn.tsx
+++ b/src/components/decode/MaskRemovalColumn.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { MaskRemovalResult } from '../../qr-decode/decode/mask-removal/types';
 import type { TriStateQR } from '../../qr-decode/types';
 import { MASK_PATTERNS, type MaskPattern } from '../../qr-encode/masking/maskPatterns';
+import { t } from '../../lang';
 
 interface MaskRemovalColumnProps {
   maskRemovalResult: MaskRemovalResult | null;
@@ -140,7 +141,7 @@ export function MaskRemovalColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">3단계: 마스크 패턴 제거</h2>
+      <h2 className="font-medium mb-3">{t('3단계: 마스크 패턴 제거', 'Step 3: Mask Removal')}</h2>
       
       <div className="space-y-4">
         <p className="text-sm text-gray-600">

--- a/src/components/decode/VersionExtractionColumn.tsx
+++ b/src/components/decode/VersionExtractionColumn.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { VersionInfoResult } from '../../qr-decode/decode/version-extraction/types';
 import type { TriStateQR } from '../../qr-decode/types';
+import { t } from '../../lang';
 
 interface VersionExtractionColumnProps {
   versionInfo: VersionInfoResult | null;
@@ -207,7 +208,7 @@ export const VersionExtractionColumn = ({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">2단계: 버전 정보 추출</h2>
+      <h2 className="font-medium mb-3">{t('2단계: 버전 정보 추출', 'Step 2: Version Extraction')}</h2>
       
       <div className="space-y-4">
         <p className="text-sm text-gray-600">

--- a/src/components/detect/BinarizationColumn.tsx
+++ b/src/components/detect/BinarizationColumn.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { BinarizationResult } from '../../qr-decode/types';
+import { t } from '../../lang';
 
 interface BinarizationColumnProps {
   binarization: BinarizationResult | null;
@@ -72,7 +73,7 @@ export function BinarizationColumn({ binarization }: BinarizationColumnProps) {
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">3단계: 이진화</h2>
+      <h2 className="font-medium mb-3">{t('3단계: 이진화', 'Step 3: Binarization')}</h2>
       
       {binarization ? (
         <div className="space-y-4">

--- a/src/components/detect/FinderDetectionColumn.tsx
+++ b/src/components/detect/FinderDetectionColumn.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { FinderDetectionResult } from '../../qr-decode/types';
+import { t } from '../../lang';
 import {
   calculateCenter,
   calculateLineIntersection,
@@ -207,7 +208,7 @@ export function FinderDetectionColumn({ finderDetection }: FinderDetectionColumn
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">4단계: 파인더 패턴 검출</h2>
+      <h2 className="font-medium mb-3">{t('4단계: 파인더 패턴 검출', 'Step 4: Finder Pattern Detection')}</h2>
 
       {finderDetection ? (
         <div className="space-y-4">

--- a/src/components/detect/GrayscaleColumn.tsx
+++ b/src/components/detect/GrayscaleColumn.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { GrayscaleResult } from '../../qr-decode/types';
+import { t } from '../../lang';
 
 interface GrayscaleColumnProps {
   grayscale: GrayscaleResult | null;
@@ -60,7 +61,7 @@ export function GrayscaleColumn({ grayscale }: GrayscaleColumnProps) {
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">2단계: 그레이스케일 변환</h2>
+      <h2 className="font-medium mb-3">{t('2단계: 그레이스케일 변환', 'Step 2: Grayscale')}</h2>
       
       {grayscale ? (
         <div className="space-y-4">

--- a/src/components/detect/ImageInputColumn/index.tsx
+++ b/src/components/detect/ImageInputColumn/index.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useState } from 'react';
 import type { ImageProcessingResult } from '../../../qr-decode/types';
 import { CameraInput } from './CameraInput';
 import { FileInput } from './FileInput';
+import { t } from '../../lang';
 
 // VirtualCameraInput를 lazy load
 const VirtualCameraInput = lazy(() =>
@@ -51,11 +52,11 @@ export function ImageInputColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">1단계: 이미지 입력</h2>
+      <h2 className="font-medium mb-3">{t('1단계: 이미지 입력', 'Step 1: Image Input')}</h2>
 
       <div className="space-y-4">
         <p className="text-sm text-gray-600">
-          QR 코드 이미지를 업로드하거나 카메라로 캐팁합니다
+          {t('QR 코드 이미지를 업로드하거나 카메라로 캡처합니다', 'Upload a QR image or capture from camera')}
         </p>
 
         {/* 입력 모드 선택 버튼 */}

--- a/src/components/detect/RefinedHomographyColumn.tsx
+++ b/src/components/detect/RefinedHomographyColumn.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { t } from '../../lang';
 import { detectFindersDirectly } from '../../qr-decode/detect/finder-detection/directFinderDetection';
 import { runFinderDetection } from '../../qr-decode/detect/finder-detection/finderDetection';
 import { applyHomography, runHomography } from '../../qr-decode/detect/homography/homography';
@@ -251,7 +252,7 @@ export function RefinedHomographyColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">5단계: 원근 변환</h2>
+      <h2 className="font-medium mb-3">{t('5단계: 원근 변환', 'Step 5: Perspective Transform')}</h2>
 
       {isProcessing ? (
         <div className="text-gray-500 text-sm">변환 중...</div>

--- a/src/components/detect/SamplingColumn.tsx
+++ b/src/components/detect/SamplingColumn.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { runSampling } from '../../qr-decode/detect/sampling/sampling';
 import type { HomographyResult, TriStateQR } from '../../qr-decode/types';
+import { t } from '../../lang';
 
 interface SamplingColumnProps {
   sampling: TriStateQR | null;
@@ -127,7 +128,7 @@ export function SamplingColumn({
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">6단계: 모듈 샘플링</h2>
+      <h2 className="font-medium mb-3">{t('6단계: 모듈 샘플링', 'Step 6: Module Sampling')}</h2>
 
       {sampling ? (
         <div className="space-y-4">

--- a/src/components/encode/DataEncodingColumn.tsx
+++ b/src/components/encode/DataEncodingColumn.tsx
@@ -1,5 +1,6 @@
 import { BitStreamViewer } from './BitStreamViewer';
 import type { EncodedData } from '../../qr-encode/encoding/dataEncoding';
+import { t } from '../../lang';
 
 interface DataEncodingColumnProps {
   encodedData: EncodedData | null;
@@ -8,7 +9,7 @@ interface DataEncodingColumnProps {
 export function DataEncodingColumn({ encodedData }: DataEncodingColumnProps) {
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">2단계: 데이터 부호화</h2>
+      <h2 className="font-medium mb-3">{t('2단계: 데이터 부호화', 'Step 2: Data Encoding')}</h2>
       <BitStreamViewer encodedData={encodedData} />
     </div>
   );

--- a/src/components/encode/ErrorCorrectionColumn.tsx
+++ b/src/components/encode/ErrorCorrectionColumn.tsx
@@ -1,4 +1,5 @@
 import type { ErrorCorrectionData } from '../../shared/types';
+import { t } from '../../lang';
 
 interface ErrorCorrectionColumnProps {
   errorCorrection: ErrorCorrectionData | null;
@@ -8,7 +9,7 @@ export function ErrorCorrectionColumn({ errorCorrection }: ErrorCorrectionColumn
   if (!errorCorrection) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">3단계: 에러 정정</h2>
+        <h2 className="font-medium mb-3">{t('3단계: 에러 정정', 'Step 3: Error Correction')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -52,7 +53,7 @@ export function ErrorCorrectionColumn({ errorCorrection }: ErrorCorrectionColumn
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">3단계: 에러 정정</h2>
+      <h2 className="font-medium mb-3">{t('3단계: 에러 정정', 'Step 3: Error Correction')}</h2>
 
       <div className="space-y-4">
         {/* 데이터 코드워드 */}

--- a/src/components/encode/FinalGenerationColumn.tsx
+++ b/src/components/encode/FinalGenerationColumn.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { FinalQRResult } from '../../qr-encode/final-generation/finalGeneration';
+import { t } from '../../lang';
 
 interface FinalGenerationColumnProps {
   finalGeneration: FinalQRResult | null;
@@ -144,7 +145,7 @@ export const FinalGenerationColumn = ({ finalGeneration }: FinalGenerationColumn
   if (!finalGeneration) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">7단계: 최종 생성</h2>
+        <h2 className="font-medium mb-3">{t('7단계: 최종 생성', 'Step 7: Final Generation')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -165,7 +166,7 @@ export const FinalGenerationColumn = ({ finalGeneration }: FinalGenerationColumn
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">7단계: 최종 생성</h2>
+      <h2 className="font-medium mb-3">{t('7단계: 최종 생성', 'Step 7: Final Generation')}</h2>
       <p className="text-sm text-gray-600 mb-4">
         완성된 QR 코드 (포맷/버전 정보 포함)
       </p>

--- a/src/components/encode/MaskingColumn.tsx
+++ b/src/components/encode/MaskingColumn.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { ModulePlacementData } from '../../shared/types';
+import { t } from '../../lang';
 import {
   generateAllMaskMatrices,
   generateAllEncodingMaskMatrices,
@@ -145,7 +146,7 @@ export const MaskingColumn = ({ modulePlacement }: MaskingColumnProps) => {
   if (!modulePlacement || !modulePlacement.subSteps || modulePlacement.subSteps.length === 0) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">6단계: 마스킹</h2>
+        <h2 className="font-medium mb-3">{t('6단계: 마스킹', 'Step 6: Masking')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -166,7 +167,7 @@ export const MaskingColumn = ({ modulePlacement }: MaskingColumnProps) => {
   if (!finalStep || !finalStep.matrix) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">6단계: 마스킹</h2>
+        <h2 className="font-medium mb-3">{t('6단계: 마스킹', 'Step 6: Masking')}</h2>
         <div className="text-gray-500 text-sm">매트릭스 데이터를 불러오는 중...</div>
       </div>
     );
@@ -189,7 +190,7 @@ export const MaskingColumn = ({ modulePlacement }: MaskingColumnProps) => {
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">6단계: 마스킹</h2>
+      <h2 className="font-medium mb-3">{t('6단계: 마스킹', 'Step 6: Masking')}</h2>
       <p className="text-sm text-gray-600 mb-4">8가지 마스크 패턴 평가 및 최적 패턴 선택</p>
 
       <div className="space-y-4 max-h-[calc(100vh-12rem)] overflow-y-auto overflow-x-auto">

--- a/src/components/encode/MessageConstructionColumn.tsx
+++ b/src/components/encode/MessageConstructionColumn.tsx
@@ -1,5 +1,6 @@
 import type { MessageConstructionResult } from '../../qr-encode/message-construction/messageConstruction';
 import { formatBitString } from '../../qr-encode/message-construction/messageConstruction';
+import { t } from '../../lang';
 
 interface MessageConstructionColumnProps {
   result: MessageConstructionResult | null;
@@ -9,7 +10,7 @@ export function MessageConstructionColumn({ result }: MessageConstructionColumnP
   if (!result) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">4단계: 최종 비트스트림</h2>
+        <h2 className="font-medium mb-3">{t('4단계: 최종 비트스트림', 'Step 4: Message Construction')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -58,7 +59,7 @@ export function MessageConstructionColumn({ result }: MessageConstructionColumnP
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">4단계: 최종 비트스트림</h2>
+      <h2 className="font-medium mb-3">{t('4단계: 최종 비트스트림', 'Step 4: Message Construction')}</h2>
 
       <div className="space-y-4">
         {/* 비트스트림 정보 */}

--- a/src/components/encode/ModulePlacementColumn.tsx
+++ b/src/components/encode/ModulePlacementColumn.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { ModulePlacementData } from '../../shared/types';
+import { t } from '../../lang';
 
 interface ModulePlacementColumnProps {
   modulePlacement: ModulePlacementData | null;
@@ -116,7 +117,7 @@ export const ModulePlacementColumn = ({ modulePlacement }: ModulePlacementColumn
   if (!modulePlacement) {
     return (
       <div className="step-column">
-        <h2 className="font-medium mb-3">5단계: 모듈 배치</h2>
+        <h2 className="font-medium mb-3">{t('5단계: 모듈 배치', 'Step 5: Module Placement')}</h2>
         
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -134,7 +135,7 @@ export const ModulePlacementColumn = ({ modulePlacement }: ModulePlacementColumn
 
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">5단계: 모듈 배치</h2>
+      <h2 className="font-medium mb-3">{t('5단계: 모듈 배치', 'Step 5: Module Placement')}</h2>
       <p className="text-sm text-gray-600 mb-4">
         {modulePlacement.size}×{modulePlacement.size} 매트릭스 | 
         데이터 모듈: {modulePlacement.usedDataModules}/{modulePlacement.totalDataModules}

--- a/src/components/encode/SettingsColumn.tsx
+++ b/src/components/encode/SettingsColumn.tsx
@@ -1,4 +1,5 @@
 import type { ErrorCorrectionLevel, DataAnalysisResult } from '../../shared/types';
+import { t } from '../../lang';
 
 interface SettingsColumnProps {
   inputData: string;
@@ -23,23 +24,23 @@ export function SettingsColumn({
 }: SettingsColumnProps) {
   return (
     <div className="step-column">
-      <h2 className="font-medium mb-3">1단계: 설정</h2>
+      <h2 className="font-medium mb-3">{t('1단계: 설정', 'Step 1: Settings')}</h2>
 
       <div className="space-y-3">
         <div>
           <div className="flex items-center justify-between mb-1">
             <label htmlFor="qr-input" className="block text-sm">
-              데이터 입력
+              {t('데이터 입력', 'Input data')}
             </label>
             {isProcessing && (
-              <span className="text-xs text-blue-600 animate-pulse">처리 중...</span>
+              <span className="text-xs text-blue-600 animate-pulse">{t('처리 중...', 'Processing...')}</span>
             )}
           </div>
           <textarea
             id="qr-input"
             value={inputData}
             onChange={(e) => setInputData(e.target.value)}
-            placeholder="QR 코드로 만들 데이터를 입력하세요..."
+            placeholder={t('QR 코드로 만들 데이터를 입력하세요...', 'Enter data to encode as QR code...')}
             className="w-full min-h-[150px] p-2 border border-gray-200 text-sm resize-none focus:outline-none focus:border-black"
             autoFocus
           />
@@ -47,26 +48,26 @@ export function SettingsColumn({
 
         <div className="text-xs space-y-0.5">
           <div className="flex justify-between">
-            <span>문자 수</span>
+            <span>{t('문자 수', 'Characters')}</span>
             <span>{inputData.length}</span>
           </div>
           <div className="flex justify-between">
-            <span>권장 모드</span>
+            <span>{t('권장 모드', 'Recommended mode')}</span>
             <span className="font-mono">{dataAnalysis?.recommendedMode || '-'}</span>
           </div>
           <div className="flex justify-between">
-            <span>최소 버전</span>
+            <span>{t('최소 버전', 'Minimum version')}</span>
             <span>{dataAnalysis?.minimumVersion || '-'}</span>
           </div>
           {dataAnalysis && !dataAnalysis.isValid && (
-            <div className="text-red-600 mt-1">용량 초과</div>
+            <div className="text-red-600 mt-1">{t('용량 초과', 'Too much data')}</div>
           )}
         </div>
 
         <div className="space-y-2">
           <div>
             <label htmlFor="qr-version" className="block mb-1 text-xs">
-              QR 버전
+              {t('QR 버전', 'QR version')}
             </label>
             <select
               id="qr-version"
@@ -88,7 +89,7 @@ export function SettingsColumn({
 
           <div>
             <label htmlFor="error-level" className="block mb-1 text-xs">
-              에러 정정 레벨
+              {t('에러 정정 레벨', 'Error correction level')}
             </label>
             <select
               id="error-level"
@@ -106,20 +107,20 @@ export function SettingsColumn({
 
         {/* 샘플 데이터 */}
         <div>
-          <h3 className="text-xs font-medium text-gray-700 mb-2">샘플 데이터</h3>
+          <h3 className="text-xs font-medium text-gray-700 mb-2">{t('샘플 데이터', 'Sample data')}</h3>
           <div className="space-y-1">
             {/* 기본 인코딩 모드 */}
             <button
               onClick={() => setInputData('123456789')}
               className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
             >
-              <span className="font-medium">숫자:</span> 123456789
+              <span className="font-medium">{t('숫자:', 'Numeric:')}</span> 123456789
             </button>
             <button
               onClick={() => setInputData('HELLO WORLD')}
               className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
             >
-              <span className="font-medium">영숫자:</span> HELLO WORLD
+              <span className="font-medium">{t('영숫자:', 'Alphanumeric:')}</span> HELLO WORLD
             </button>
             <button
               onClick={() => setInputData('https://example.com')}
@@ -131,24 +132,24 @@ export function SettingsColumn({
               onClick={() => setInputData('안녕하세요 QR코드')}
               className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
             >
-              <span className="font-medium">한글:</span> 안녕하세요 QR코드
+              <span className="font-medium">{t('한글:', 'Korean:')}</span> 안녕하세요 QR코드
             </button>
             <button
               onClick={() => setInputData('Mixed123한글')}
               className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
             >
-              <span className="font-medium">혼합:</span> Mixed123한글
+              <span className="font-medium">{t('혼합:', 'Mixed:')}</span> Mixed123한글
             </button>
 
             {/* 실용적인 케이스들 */}
             <div className="border-t border-gray-200 pt-2 mt-2">
-              <div className="text-[10px] text-gray-500 mb-1">실용 사례</div>
+              <div className="text-[10px] text-gray-500 mb-1">{t('실용 사례', 'Practical cases')}</div>
 
               <button
                 onClick={() => setInputData('WIFI:T:WPA;S:MyWiFi;P:password123;H:false;;')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">Wi-Fi:</span> 네트워크 연결
+                <span className="font-medium">Wi-Fi:</span> {t('네트워크 연결', 'Connect to Wi-Fi')}
               </button>
 
               <button
@@ -159,7 +160,7 @@ export function SettingsColumn({
                 }
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">연락처:</span> vCard 형식
+                <span className="font-medium">{t('연락처:', 'Contact:')}</span> vCard 형식
               </button>
 
               <button
@@ -170,14 +171,14 @@ export function SettingsColumn({
                 }
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">이메일:</span> 메일 작성
+                <span className="font-medium">{t('이메일:', 'Email:')}</span> 메일 작성
               </button>
 
               <button
                 onClick={() => setInputData('tel:+82-10-1234-5678')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">전화:</span> 통화 연결
+                <span className="font-medium">{t('전화:', 'Telephone:')}</span> 통화 연결
               </button>
 
               <button
@@ -186,21 +187,21 @@ export function SettingsColumn({
                 }
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">SMS:</span> 문자 메시지
+                <span className="font-medium">SMS:</span> {t('문자 메시지', 'Text message')}
               </button>
 
               <button
                 onClick={() => setInputData('geo:37.5665,126.9780?q=서울특별시청')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">위치:</span> 지도 좌표
+                <span className="font-medium">{t('위치:', 'Location:')}</span> 지도 좌표
               </button>
 
               <button
                 onClick={() => setInputData('https://github.com/yongsk0066/qr-visualizer')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">GitHub:</span> 프로젝트 링크
+                <span className="font-medium">GitHub:</span> {t('프로젝트 링크', 'Project link')}
               </button>
 
               <button
@@ -223,49 +224,49 @@ export function SettingsColumn({
                 }} // cspell:disable-line
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">캘린더:</span> Christmas Party
+                <span className="font-medium">{t('캘린더:', 'Calendar:')}</span> Christmas Party
               </button>
 
               <button
                 onClick={() => setInputData('https://www.youtube.com/watch?v=dQw4w9WgXcQ')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">YouTube:</span> 동영상 링크
+                <span className="font-medium">YouTube:</span> {t('동영상 링크', 'Video link')}
               </button>
 
               <button
                 onClick={() => setInputData('market://details?id=com.android.chrome')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">앱스토어:</span> 앱 다운로드
+                <span className="font-medium">{t('앱스토어:', 'App store:')}</span> {t('앱 다운로드', 'Download app')}
               </button>
 
               <button
                 onClick={() => setInputData('fb://profile/100000000000000')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">Facebook:</span> 프로필 연결
+                <span className="font-medium">Facebook:</span> {t('프로필 연결', 'Profile')}
               </button>
 
               <button
                 onClick={() => setInputData('instagram://user?username=yongsk0066')} // cspell:disable-line
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">Instagram:</span> 프로필 방문
+                <span className="font-medium">Instagram:</span> {t('프로필 방문', 'Visit profile')}
               </button>
 
               <button
                 onClick={() => setInputData('spotify:track:2zPANzQTt5Nbkg0eBPb7HI')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">Spotify:</span> 음악 재생
+                <span className="font-medium">Spotify:</span> {t('음악 재생', 'Play music')}
               </button>
 
               <button
                 onClick={() => setInputData('https://maps.google.com/maps?q=37.5665,126.9780')}
                 className="w-full text-left text-xs p-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none"
               >
-                <span className="font-medium">Google Maps:</span> 위치 공유
+                <span className="font-medium">Google Maps:</span> {t('위치 공유', 'Share location')}
               </button>
             </div>
           </div>

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -1,0 +1,3 @@
+export function t(ko: string, en: string): string {
+  return document.documentElement.lang.startsWith('en') ? en : ko;
+}


### PR DESCRIPTION
## Summary
- introduce simple `t()` function for Korean/English translation
- add English strings for headings and placeholder texts
- create `index-en.html` for a static English page

## Testing
- `yarn test` *(fails: No projects matched)*

------
https://chatgpt.com/codex/tasks/task_e_685ab367004883339a25590e8626569a